### PR TITLE
Update IPEX import and device definition

### DIFF
--- a/src/training.py
+++ b/src/training.py
@@ -151,8 +151,7 @@ if __name__ == "__main__":
     class_weight = [1, 3] if NEG_CLASS == 1 else [3, 1]
     DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     if intel_flag:
-        import intel_pytorch_extension as ipex
-        DEVICE = ipex.DEVICE
+        import intel_extension_for_pytorch as ipex
 
     HEATMAP_THRESH = 0.7
     N_CV_FOLDS = 3


### PR DESCRIPTION
- intel_pytorch_extension has been renamed to intel_extension_for_pytorch for legal reasons (the prior no longer exists in any of the conda or pip channels)
- you no longer need to specify ipex.DEVICE from the ipex documentation "The underhood device is changed from the extension-specific device(XPU) to the standard CPU device which aligns with PyTorch CPU device design regardless of the dispatch mechanism and operator register mechanism. The interface impactions are that the model does not need to be converted to the extension device explicitly." https://intel.github.io/intel-extension-for-pytorch/1.10.100/tutorials/releases.html#highlights